### PR TITLE
Handle multi-GPU memory for Qwen model

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,9 @@ How to run the Kaggle notebook (short checklist)
 
 Notes about hardware on Kaggle
 - For non-API multimodal runs you will need 2  NVIDIA T4 GPUs.
+- The agent automatically assigns ~14GiB of memory per GPU so the 30B
+  Qwen model can be sharded across both devices without running out of
+  memory.
 - For text-only (non-API) a single GPU (T4) is typically sufficient.
 - API mode uses cloud models and is tolerant of CPU-only environments.
 


### PR DESCRIPTION
## Summary
- Prevent OOM when loading Qwen3 30B locally by assigning 14GiB per available GPU
- Document multi-GPU sharding behavior in README
- Stop GPT-OSS from looping on the same tool by tracking consecutive calls and forcing a final answer
- Harden tool-call parsing against malformed JSON and expand web-search tool description with clear termination guidance

## Testing
- `python -m py_compile agent.py custom_models.py`
- `WANDB_MODE=offline python agent.py --help` *(fails: gpl.transport.exceptions.TransportConnectionFailed: HTTPSConnectionPool(host='api.wandb.ai', port=443): Max retries exceeded with url: /graphql (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*


------
https://chatgpt.com/codex/tasks/task_e_68c6eeb472f8832686844afa8d813bcb